### PR TITLE
Add generated AccessionNumber to DICOM

### DIFF
--- a/BadMedicine.Dicom.Tests/DicomDataGeneratorTests.cs
+++ b/BadMedicine.Dicom.Tests/DicomDataGeneratorTests.cs
@@ -36,6 +36,8 @@ namespace BadMedicine.Dicom.Tests
             datasetCreated.Dataset.GetValues<DicomUID>(DicomTag.StudyInstanceUID)[0].UID,
             "UID in the dicom file generated did not match the one output into the CSV inventory file"
             );
+
+            Assert.IsNotEmpty(datasetCreated.Dataset.GetSingleValue<String>(DicomTag.AccessionNumber));
             
             Console.WriteLine("Created file "+ f.FullName);
 

--- a/BadMedicine.Dicom/DicomDataGenerator.cs
+++ b/BadMedicine.Dicom/DicomDataGenerator.cs
@@ -233,6 +233,7 @@ namespace BadMedicine.Dicom
             ds.AddOrUpdate(new DicomTime(DicomTag.SeriesTime, DateTime.Today + series.SeriesTime));
                         
             ds.AddOrUpdate(DicomTag.Modality,series.Modality);
+            ds.AddOrUpdate(DicomTag.AccessionNumber, series.Study.AccessionNumber?? "");
             
             if(series.Study.StudyDescription != null)
                 ds.AddOrUpdate(DicomTag.StudyDescription,series.Study.StudyDescription);


### PR DESCRIPTION
This PR adds AccessionNumber to created DICOM instances, including a test case. AccessionNumber is a required tag, that should be empty when unknown. 