### PR TITLE
Added support for specifying explicit UIDs to use when generating images

### DIFF
--- a/BadDicom/BadDicom.template.yaml
+++ b/BadDicom/BadDicom.template.yaml
@@ -13,3 +13,7 @@
   MakeDistinct: true
   #The number of parallel batches to execute (each batch gets the full count of studies then they are merged at the end
   Batches: 1
+UIDs:
+  StudyInstanceUIDs: ./StudyInstanceUIDs.csv
+  SeriesInstanceUIDs: ./SeriesInstanceUIDs.csv
+  SOPInstanceUIDs: ./SOPInstanceUIDs.csv

--- a/BadDicom/Configuration/Config.cs
+++ b/BadDicom/Configuration/Config.cs
@@ -3,5 +3,6 @@
     class Config
     {
         public TargetDatabase Database { get;set; }
+        public ExplicitUIDs UIDs { get; set; }
     }
 }

--- a/BadDicom/Configuration/ExplicitUIDs.cs
+++ b/BadDicom/Configuration/ExplicitUIDs.cs
@@ -1,0 +1,60 @@
+﻿using BadMedicine.Dicom;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace BadDicom.Configuration
+{
+    /// <summary>
+    /// Config section for loading explicit UIDs from disk and using those in file creation
+    /// </summary>
+    public class ExplicitUIDs
+    {
+        /// <summary>
+        /// Path to a file containing a list of study instance UIDs to use
+        /// </summary>
+        public string StudyInstanceUIDs { get; set; }
+
+        /// <summary>
+        /// Path to a file containing a list of series instance UIDs to use
+        /// </summary>
+        public string SeriesInstanceUIDs { get; set; }
+
+        /// <summary>
+        /// Path to a file containing a list of SOP instance UIDs to use
+        /// </summary>
+        public string SOPInstanceUIDs { get; set; }
+
+        /// <summary>
+        /// Loads the UID files referenced (if they exist) in the configuration
+        /// and populates <see cref="UIDAllocator"/> with the values.
+        /// </summary>
+        public void Load()
+        {
+            // unlikely but if someone else has pre queued some stuff, this replaces that
+            UIDAllocator.StudyUIDs.Clear();
+            UIDAllocator.SeriesUIDs.Clear();
+            UIDAllocator.SOPUIDs.Clear();
+
+            foreach (var u in GetUIDsFrom(StudyInstanceUIDs))
+                UIDAllocator.StudyUIDs.Enqueue(u);
+
+            foreach (var u in GetUIDsFrom(SeriesInstanceUIDs))
+                UIDAllocator.SeriesUIDs.Enqueue(u);
+
+            foreach (var u in GetUIDsFrom(SOPInstanceUIDs))
+                UIDAllocator.SOPUIDs.Enqueue(u);
+        }
+
+        private IEnumerable<string> GetUIDsFrom(string path)
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                var lines = File.ReadAllLines(StudyInstanceUIDs);
+                return lines.Where(l => !string.IsNullOrWhiteSpace(l));
+            }
+
+            return Enumerable.Empty<string>();
+        }
+    }
+}

--- a/BadDicom/Configuration/ExplicitUIDs.cs
+++ b/BadDicom/Configuration/ExplicitUIDs.cs
@@ -48,13 +48,9 @@ namespace BadDicom.Configuration
 
         private IEnumerable<string> GetUIDsFrom(string path)
         {
-            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
-            {
-                var lines = File.ReadAllLines(StudyInstanceUIDs);
-                return lines.Where(l => !string.IsNullOrWhiteSpace(l));
-            }
-
-            return Enumerable.Empty<string>();
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return Enumerable.Empty<string>();
+            
+            return File.ReadLines(StudyInstanceUIDs).Where(l => !string.IsNullOrWhiteSpace(l));
         }
     }
 }

--- a/BadDicom/Program.cs
+++ b/BadDicom/Program.cs
@@ -72,10 +72,7 @@ namespace BadDicom
                     return;
                 }
 
-                if(config.UIDs != null)
-                {
-                    config.UIDs.Load();
-                }
+                config.UIDs?.Load();
 
                 if (config.Database != null)
                 {

--- a/BadDicom/Program.cs
+++ b/BadDicom/Program.cs
@@ -72,6 +72,11 @@ namespace BadDicom
                     return;
                 }
 
+                if(config.UIDs != null)
+                {
+                    config.UIDs.Load();
+                }
+
                 if (config.Database != null)
                 {
                     try

--- a/BadMedicine.Dicom.Tests/StudyTests.cs
+++ b/BadMedicine.Dicom.Tests/StudyTests.cs
@@ -31,5 +31,32 @@ namespace BadMedicine.Dicom.Tests
             generator.Dispose();
 
         }
+
+        [Test]
+        public void Test_UsingExplicitUIDs()
+        {
+            UIDAllocator.StudyUIDs.Enqueue("999");
+            UIDAllocator.SeriesUIDs.Enqueue("888");
+            UIDAllocator.SOPUIDs.Enqueue("777");
+
+            var r = new Random(100);
+
+            var generator = new DicomDataGenerator(r, null);
+
+            var p = new Person(r);
+
+            Study study = new(generator, p, new("MR", 2, 0, 50, 0, r), r);
+
+            Assert.AreEqual("999", study.StudyUID.UID);
+            Assert.AreEqual("888", study.Series[0].SeriesUID.UID);
+
+            var image1 = study.Series[0].Datasets[0];
+            Assert.AreEqual("999", image1.GetSingleValue<DicomUID>(DicomTag.StudyInstanceUID).UID);
+            Assert.AreEqual("888", image1.GetSingleValue<DicomUID>(DicomTag.SeriesInstanceUID).UID);
+            Assert.AreEqual("777", image1.GetSingleValue<DicomUID>(DicomTag.SOPInstanceUID).UID);
+
+            generator.Dispose();
+
+        }
     }
 }

--- a/BadMedicine.Dicom.Tests/StudyTests.cs
+++ b/BadMedicine.Dicom.Tests/StudyTests.cs
@@ -9,10 +9,9 @@ namespace BadMedicine.Dicom.Tests
         [Test]
         public void Test_CreatingNewStudy_HasSomeImages()
         {
-
             var r = new Random(100);
 
-            var generator = new DicomDataGenerator(r,null);
+            using var generator = new DicomDataGenerator(r,null) {NoPixels = true};
 
             var p = new Person(r);
             
@@ -27,9 +26,6 @@ namespace BadMedicine.Dicom.Tests
                 Assert.AreEqual("MR",ds.GetValues<string>(DicomTag.Modality)[0]);
                 Assert.AreEqual(study.StudyTime,ds.GetSingleValue<DateTime>(DicomTag.StudyTime).TimeOfDay);
             }
-
-            generator.Dispose();
-
         }
 
         [Test]
@@ -41,7 +37,7 @@ namespace BadMedicine.Dicom.Tests
 
             var r = new Random(100);
 
-            var generator = new DicomDataGenerator(r, null);
+            using var generator = new DicomDataGenerator(r, null) {NoPixels = true};
 
             var p = new Person(r);
 
@@ -54,9 +50,6 @@ namespace BadMedicine.Dicom.Tests
             Assert.AreEqual("999", image1.GetSingleValue<DicomUID>(DicomTag.StudyInstanceUID).UID);
             Assert.AreEqual("888", image1.GetSingleValue<DicomUID>(DicomTag.SeriesInstanceUID).UID);
             Assert.AreEqual("777", image1.GetSingleValue<DicomUID>(DicomTag.SOPInstanceUID).UID);
-
-            generator.Dispose();
-
         }
     }
 }

--- a/BadMedicine.Dicom/DicomDataGenerator.cs
+++ b/BadMedicine.Dicom/DicomDataGenerator.cs
@@ -221,7 +221,7 @@ namespace BadMedicine.Dicom
             ds.AddOrUpdate(DicomTag.StudyInstanceUID,series.Study.StudyUID);
             ds.AddOrUpdate(DicomTag.SeriesInstanceUID,series.SeriesUID);
 
-            DicomUID sopInstanceUID = DicomUID.Generate();
+            DicomUID sopInstanceUID = UIDAllocator.GenerateSOPInstanceUID();
             ds.AddOrUpdate(DicomTag.SOPInstanceUID,sopInstanceUID);
             ds.AddOrUpdate(DicomTag.SOPClassUID , DicomUID.SecondaryCaptureImageStorage);
             

--- a/BadMedicine.Dicom/Series.cs
+++ b/BadMedicine.Dicom/Series.cs
@@ -86,7 +86,7 @@ namespace BadMedicine.Dicom
 
         internal Series(Study study, Person person, string modality, string imageType, int imageCount, DescBodyPart part = null)
         {
-            SeriesUID = DicomUID.Generate();
+            SeriesUID = UIDAllocator.GenerateSeriesInstanceUID();
 
             this.Study = study;
             this.person = person;

--- a/BadMedicine.Dicom/Study.cs
+++ b/BadMedicine.Dicom/Study.cs
@@ -63,7 +63,7 @@ namespace BadMedicine.Dicom
         {
             /////////////////////// Generate all the Study Values ////////////////////
             Parent = parent;
-            StudyUID = DicomUID.Generate();
+            StudyUID = UIDAllocator.GenerateStudyInstanceUID();
             StudyDate = person.GetRandomDateDuringLifetime(r).Date;
 
             var stats = DicomDataGeneratorStats.GetInstance(r);

--- a/BadMedicine.Dicom/UIDAllocator.cs
+++ b/BadMedicine.Dicom/UIDAllocator.cs
@@ -1,0 +1,67 @@
+﻿using FellowOakDicom;
+using System.Collections.Concurrent;
+
+namespace BadMedicine.Dicom
+{
+    /// <summary>
+    /// Allocates <see cref="DicomUID"/> values from an explicit list(s) or
+    /// by calling <see cref="DicomUID.Generate"/>.
+    /// </summary>
+    public class UIDAllocator
+    {
+        /// <summary>
+        /// Explicit <see cref="DicomUID"/> string values to use when allocating uids for studies
+        /// </summary>
+        public static ConcurrentQueue<string> StudyUIDs = new ();
+
+
+        /// <summary>
+        /// Explicit <see cref="DicomUID"/> string values to use when allocating uids for series
+        /// </summary>
+        public static ConcurrentQueue<string> SeriesUIDs = new();
+
+        /// <summary>
+        /// Explicit <see cref="DicomUID"/> string values to use when allocating uids for images
+        /// </summary>
+        public static ConcurrentQueue<string> SOPUIDs = new();
+
+        /// <summary>
+        /// Returns a new <see cref="DicomUID"/> from <see cref="StudyUIDs"/> or allocated
+        /// with <see cref="DicomUID.Generate"/>
+        /// </summary>
+        /// <returns></returns>
+        public static DicomUID GenerateStudyInstanceUID()
+        {
+            if (StudyUIDs.TryDequeue(out string result))
+                return new DicomUID(result, "Local UID", DicomUidType.Unknown);
+
+            return DicomUID.Generate();
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="DicomUID"/> from <see cref="SeriesUIDs"/> or allocated
+        /// with <see cref="DicomUID.Generate"/>
+        /// </summary>
+        /// <returns></returns>
+        public static DicomUID GenerateSeriesInstanceUID()
+        {
+            if (SeriesUIDs.TryDequeue(out string result))
+                return new DicomUID(result, "Local UID", DicomUidType.Unknown);
+
+            return DicomUID.Generate();
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="DicomUID"/> from <see cref="SOPUIDs"/> or allocated
+        /// with <see cref="DicomUID.Generate"/>
+        /// </summary>
+        /// <returns></returns>
+        public static DicomUID GenerateSOPInstanceUID()
+        {
+            if (SOPUIDs.TryDequeue(out string result))
+                return new DicomUID(result, "Local UID", DicomUidType.Unknown);
+
+            return DicomUID.Generate();
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+- Added support for specifying explicit UIDs to use when generating images
 - Added linked statistics for frequency of StudyDescription, SeriesDescription and BodyPartExamined for CT
 
 ## [0.0.12] - 2022-05-18


### PR DESCRIPTION
Specify explicit UIDs by renaming `BadDicom.template.yaml` to `BadDicom.yaml` and creating the 3 UID files referenced in it (also delete the `Database:` section of the config unless you want that too).

Fixes  #98

![image](https://user-images.githubusercontent.com/31306100/170247532-a44f8036-58d5-4ced-84c0-5e85d838492d.png)
