### PR TITLE
Use PN value representation for patient name

### DIFF
--- a/BadMedicine.Dicom/DicomDataGenerator.cs
+++ b/BadMedicine.Dicom/DicomDataGenerator.cs
@@ -285,7 +285,7 @@ public class DicomDataGenerator : DataGenerator,IDisposable
 
         //patient details
         ds.AddOrUpdate(DicomTag.PatientID, p.CHI);
-        ds.AddOrUpdate(DicomTag.PatientName, $"{p.Forename} {p.Surname}");
+        ds.AddOrUpdate(DicomTag.PatientName, $"{p.Surname}^{p.Forename}");
         ds.AddOrUpdate(DicomTag.PatientBirthDate, p.DateOfBirth);
 
         if (p.Address != null)


### PR DESCRIPTION
The value representation of the patient name tag should be PN (patient name). When the name is not PN encoded, data cannot be inferred correctly by consumers of the generated study.